### PR TITLE
Hash passwords before storing demo users

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+# Luxury Cars (Demo)
+
+This demo stores bookings, reviews, and basic account data in browser `localStorage`.
+
+## Authentication note
+Passwords are hashed with SHA-256 before being written to the `lux-users` key to avoid storing them in plain text. This is suitable for demo purposes only because storage and verification all happen client-side. For any production deployment, replace this local approach with a managed authentication provider (e.g., Auth0, Cognito, Clerk) or a server-backed identity service that can securely handle credential storage, session management, and multi-factor protections.

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -252,11 +252,11 @@ function attachAuth() {
     })
   );
 
-  loginForm.addEventListener("submit", (e) => {
+  loginForm.addEventListener("submit", async (e) => {
     e.preventDefault();
     const data = new FormData(loginForm);
     try {
-      loginUser({ email: data.get("email"), password: data.get("password") });
+      await loginUser({ email: data.get("email"), password: data.get("password") });
       showToast("Signed in");
       closeModals();
       updateSessionUI();
@@ -265,11 +265,11 @@ function attachAuth() {
     }
   });
 
-  registerForm.addEventListener("submit", (e) => {
+  registerForm.addEventListener("submit", async (e) => {
     e.preventDefault();
     const data = new FormData(registerForm);
     try {
-      registerUser({
+      await registerUser({
         name: data.get("name"),
         email: data.get("email"),
         password: data.get("password")

--- a/scripts/data.js
+++ b/scripts/data.js
@@ -137,5 +137,11 @@ export const seedReviews = [
 ];
 
 export const seedUsers = [
-  { id: "admin", name: "Admin", email: "admin@aurumdrive.com", password: "admin123", role: "admin" }
+  {
+    id: "admin",
+    name: "Admin",
+    email: "admin@aurumdrive.com",
+    password: "240be518fabd2724ddb6f04eeb1da5967448d7e831c08c8fa822809f74c720a9",
+    role: "admin"
+  }
 ];


### PR DESCRIPTION
## Summary
- hash local user passwords with SHA-256 and migrate stored entries before use
- update authentication flows to await hashed comparisons and seed the admin user with a hashed password
- note that the client-side auth approach is for demos only and should be replaced with a production-grade provider

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69256a8c97ec8327855b8ad746f21815)