### PR TITLE
Add client-side booking availability validation

### DIFF
--- a/scripts/state.js
+++ b/scripts/state.js
@@ -88,6 +88,12 @@ export function getBrands() {
   return Array.from(new Set(vehicles.map((v) => v.brand)));
 }
 
+function isWithinAvailability(car, from, to) {
+  if (from && new Date(from) < new Date(car.availableFrom)) return false;
+  if (to && new Date(to) > new Date(car.availableTo)) return false;
+  return true;
+}
+
 export function filterVehicles(criteria = {}) {
   const { brand, type, price, from, to, features = [], special } = criteria;
   return vehicles.filter((car) => {
@@ -96,10 +102,19 @@ export function filterVehicles(criteria = {}) {
     if (price && car.pricePerDay > price) return false;
     if (special && !car.isSpecial) return false;
     if (features.length && !features.every((f) => car.features.includes(f))) return false;
-    if (from && new Date(from) < new Date(car.availableFrom)) return false;
-    if (to && new Date(to) > new Date(car.availableTo)) return false;
+    if (!isWithinAvailability(car, from, to)) return false;
     return true;
   });
+}
+
+export function getVehicle(vehicleId) {
+  return vehicles.find((v) => v.id === vehicleId) || null;
+}
+
+export function isVehicleAvailable(vehicleId, from, to) {
+  const vehicle = getVehicle(vehicleId);
+  if (!vehicle) return false;
+  return isWithinAvailability(vehicle, from, to);
 }
 
 export function createBooking(vehicleId, payload) {


### PR DESCRIPTION
## Summary
- add shared vehicle availability helpers to keep filtering and booking aligned
- validate booking dates on the client for order and availability window before submission
- show friendly toasts when booking date validation fails

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69256a8979008327ac377359cb3af7ca)