### PR TITLE
Add animated page transitions

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
   <link rel="stylesheet" href="styles/main.css">
 </head>
 <body>
+  <div class="page-transition" id="page-transition"></div>
   <div class="page">
     <header class="hero" id="top">
       <nav class="nav">

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -46,6 +46,7 @@ const navLinks = document.querySelector(".nav-links");
 const heroTitle = document.querySelector(".hero-visual h3");
 const heroPill = document.querySelector(".hero-visual .pill");
 const heroImage = document.querySelector(".hero-car img");
+const pageTransition = document.getElementById("page-transition");
 
 let selectedVehicle = null;
 let activeFeatures = [];
@@ -447,12 +448,63 @@ function animateScroll() {
   document.querySelectorAll(".card, .glass, .step, .section-header").forEach((el) => observer.observe(el));
 }
 
+function revealPageTransition() {
+  if (!pageTransition) return;
+  pageTransition.classList.add("visible", "is-revealing");
+  pageTransition.addEventListener(
+    "animationend",
+    () => {
+      pageTransition.classList.remove("is-revealing", "visible");
+    },
+    { once: true }
+  );
+}
+
+function navigateWithTransition(href) {
+  if (!pageTransition) {
+    window.location.href = href;
+    return;
+  }
+  pageTransition.classList.remove("is-revealing");
+  pageTransition.classList.add("visible", "is-covering");
+  pageTransition.addEventListener(
+    "animationend",
+    () => {
+      window.location.href = href;
+    },
+    { once: true }
+  );
+}
+
+function attachPageTransitions() {
+  if (!pageTransition) return;
+
+  revealPageTransition();
+
+  document.querySelectorAll("a[href]").forEach((link) => {
+    const href = link.getAttribute("href");
+    const isHashLink = href?.startsWith("#");
+    if (!href || isHashLink || link.target === "_blank") return;
+
+    link.addEventListener("click", (event) => {
+      if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+      event.preventDefault();
+      navigateWithTransition(link.href);
+    });
+  });
+
+  window.addEventListener("beforeunload", () => {
+    pageTransition.classList.add("visible", "is-covering");
+  });
+}
+
 function initAdmin() {
   renderAdminTables(getAdminTables());
   setMetrics(getAnalytics());
 }
 
 function init() {
+  attachPageTransitions();
   populateBrandOptions();
   bindFilterChips();
   attachFilters();

--- a/styles/main.css
+++ b/styles/main.css
@@ -22,6 +22,10 @@
   box-sizing: border-box;
 }
 
+html {
+  scroll-behavior: smooth;
+}
+
 body {
   margin: 0;
   font-family: "Manrope", system-ui, -apple-system, sans-serif;
@@ -30,6 +34,31 @@ body {
   background-size: 200% 200%;
   animation: drift 18s ease-in-out infinite;
   line-height: 1.6;
+}
+
+.page-transition {
+  position: fixed;
+  inset: 0;
+  background: radial-gradient(circle at 20% 30%, rgba(213, 178, 87, 0.18), transparent 38%),
+    radial-gradient(circle at 80% 20%, rgba(93, 213, 255, 0.16), transparent 32%),
+    rgba(5, 6, 10, 0.92);
+  z-index: 9999;
+  pointer-events: none;
+  opacity: 0;
+  transform: scale(1.02);
+  filter: saturate(1.2);
+}
+
+.page-transition.visible {
+  pointer-events: auto;
+}
+
+.page-transition.is-covering {
+  animation: page-cover 420ms ease forwards;
+}
+
+.page-transition.is-revealing {
+  animation: page-reveal 620ms ease forwards;
 }
 
 .page {
@@ -968,6 +997,38 @@ input[type="checkbox"] {
   100% {
     opacity: 1;
     transform: translateY(0);
+  }
+}
+
+@keyframes page-cover {
+  from {
+    opacity: 0;
+    transform: scale(1.015);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@keyframes page-reveal {
+  from {
+    opacity: 1;
+    transform: scale(1);
+  }
+  to {
+    opacity: 0;
+    transform: scale(1.02);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  .page-transition {
+    display: none;
   }
 }
 


### PR DESCRIPTION
## Summary
- add a reusable page transition overlay to frame navigation between pages
- style the transition layer with smooth fade animations and respect reduced-motion preferences
- wire link navigation into the animated transition flow and enable smooth scrolling between sections

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69256c658d9c8327abd71e45051b5d06)