### PR TITLE
Fix register button being blocked by auth modal overlay

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -977,6 +977,7 @@ input[type="checkbox"] {
   border-radius: 999px;
   filter: blur(40px);
   opacity: 0.5;
+  pointer-events: none;
 }
 
 .auth-shell::before {


### PR DESCRIPTION
## Summary
- allow clicks on auth modal controls by disabling pointer events on decorative glow overlays

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692577fa058883279bafa76dd7ebab8f)